### PR TITLE
metainfo: set length value to actual value

### DIFF
--- a/data/dev.rotstein.SmashedPumpkin.metainfo.xml.in
+++ b/data/dev.rotstein.SmashedPumpkin.metainfo.xml.in
@@ -45,7 +45,7 @@
     </screenshot>
   </screenshots>
   <requires>
-    <display_length compare="ge">360</display_length>
+    <display_length compare="ge">600</display_length>
   </requires>
   <supports>
     <control>keyboard</control>


### PR DESCRIPTION
Hi!

First let me thank you for creating this nice app!

Unfortunately, the metadata is [wrongly advertising the app as fitting screens that are 360 logical pixels wide](https://github.com/Rotstein007/smashed-pumpkin/blob/master/data/dev.rotstein.SmashedPumpkin.metainfo.xml.in#L48). 360px is kind of the "magical width" for #LinuxMobile (e.g., on devices running postmarketOS, Mobian or Droidian), see as [this list](https://linuxphoneapps.org/docs/resources/developer-information/#hardware-specs-to-consider) I've compiled shows.

The current release Smashed Pumpkin is unfortunately wider in reality (measured with [Length](https://flathub.org/en/apps/io.github.herve4m.Length):

<img width="821" height="512" alt="Screenshot From 2026-01-18 14-17-16" src="https://github.com/user-attachments/assets/8501ea37-36d3-49ed-af4a-d174aeb77cb6" />

To solve this, adjusting the metadata value from 360px to the actually measured value as this PR does (or removing the line and the line before and after) would be enough. 

If mobile support is in scope, I'll happily help with testing. IMHO, you don't necessarily need a phone even to develop for Linux Mobile support, any touchscreen device and the length app should go most of the way.

Hope this helps!

Cheers,
Peter
